### PR TITLE
Kill thread and Add task

### DIFF
--- a/src/Kernel/Include/sched.h
+++ b/src/Kernel/Include/sched.h
@@ -12,4 +12,5 @@ typedef struct tcb {
 #endif
 } tcb;
 
+
 #endif

--- a/src/Kernel/Include/systemcall.h
+++ b/src/Kernel/Include/systemcall.h
@@ -1,4 +1,5 @@
 #ifndef __SYSTEMCALL_H__
 #define __SYSTEMCALL_H__
 void wee_os_syscall_yield(void);
+void wee_os_syscall_kill(void);
 #endif

--- a/src/Kernel/Include/weeOs.h
+++ b/src/Kernel/Include/weeOs.h
@@ -21,6 +21,8 @@
 
 /*System Calls*/
 #define wee_os_yield(); wee_os_system_call(1);
+#define wee_os_kill(); wee_os_system_call(2);
+
 
 void wee_os_launch(uint32_t quanta);
 void wee_os_init(void);

--- a/src/Kernel/Src/system_call.c
+++ b/src/Kernel/Src/system_call.c
@@ -35,18 +35,17 @@ void wee_os_syscall_yield(void)
 #ifdef weighted_round_robin
 	current_tcb->c_weight = 0;
 #endif
+	SysTick->VAL = 0;
 	SCB->ICSR |= SCB_ICSR_PENDSTSET_Msk;
 }
 
 
 void wee_os_syscall_kill(void)
 {
-	__disable_irq();
-
-	if(current_tcb->next_tcb == current_tcb)
+        if(current_tcb->next_tcb == current_tcb)
 	{
 		__enable_irq();
-		return 0;
+		return;
 	}
 
 	if(current_tcb->pid != 0)

--- a/src/Kernel/Src/system_call.c
+++ b/src/Kernel/Src/system_call.c
@@ -3,6 +3,7 @@
 #include <systemcall.h>
 
 extern tcb *current_tcb;
+extern char active_tasks[MAX_TASKS];
 
 uint32_t c=0;
 
@@ -59,6 +60,7 @@ void wee_os_syscall_kill(void)
 		temp_tcb->next_tcb = current_tcb->next_tcb;
 	}
 
+	active_tasks[current_tcb->pid] = 0;
 	__enable_irq();
 	wee_os_syscall_yield();
 }

--- a/src/Kernel/Src/system_call.c
+++ b/src/Kernel/Src/system_call.c
@@ -35,6 +35,7 @@ void wee_os_syscall_yield(void)
 #ifdef weighted_round_robin
 	current_tcb->c_weight = 0;
 #endif
+	SysTick->VAL = 0;
 	SCB->ICSR |= SCB_ICSR_PENDSTSET_Msk;
 }
 

--- a/src/Kernel/Src/system_call.c
+++ b/src/Kernel/Src/system_call.c
@@ -35,7 +35,6 @@ void wee_os_syscall_yield(void)
 #ifdef weighted_round_robin
 	current_tcb->c_weight = 0;
 #endif
-	SysTick->VAL = 0;
 	SCB->ICSR |= SCB_ICSR_PENDSTSET_Msk;
 }
 

--- a/src/Kernel/Src/weeOs.c
+++ b/src/Kernel/Src/weeOs.c
@@ -25,8 +25,10 @@ uint8_t wee_os_addthread(void(*task)(void)
 	uint32_t counter = 0;
 	while(active_tasks[counter] != 0){
 		counter++;
-		if (counter>MAX_TASKS)
+		if (counter>MAX_TASKS){
+			__enable_irq();
 			return 0;
+		}
 	}
 
 	uint32_t task_num = task_ptr - &tcbs[0];

--- a/src/Kernel/Src/weeOs.c
+++ b/src/Kernel/Src/weeOs.c
@@ -24,8 +24,10 @@ uint8_t wee_os_addthread(void(*task)(void)
 	tcb *task_ptr=&tcbs[0];
 	uint32_t counter = 0;
 	while(active_tasks[counter] != 0){
+		task_ptr++;
 		counter++;
 		if (counter>MAX_TASKS){
+			__enable_irq();
 			return 0;
 		}
 	}
@@ -49,6 +51,7 @@ uint8_t wee_os_addthread(void(*task)(void)
 				if(first_occ == &tcbs[0])
 					first_occ += counter;
 				last_occ = &tcbs[0]+counter;
+                        }
 			counter++;
 		}
 

--- a/src/Kernel/Src/weeOs.c
+++ b/src/Kernel/Src/weeOs.c
@@ -2,8 +2,9 @@
 #include <sched.h>
 
 tcb tcbs[MAX_TASKS];
-tcb *task_ptr=&tcbs[0];
 tcb *current_tcb = &tcbs[0];
+char active_tasks[MAX_TASKS] = {0};
+
 
 int32_t STACK[MAX_TASKS][STACK_SIZE];
 
@@ -20,27 +21,54 @@ uint8_t wee_os_addthread(void(*task)(void)
 		)
 {
 	__disable_irq();
+	tcb *task_ptr=&tcbs[0];
+	uint32_t counter = 0;
+	while(active_tasks[counter] != 0){
+		counter++;
+		if (counter>MAX_TASKS)
+			return 0;
+	}
+
 	uint32_t task_num = task_ptr - &tcbs[0];
-	if (task_num>MAX_TASKS)
-		return 0;
 
-	if (task_ptr != &tcbs[0])
+	if (task_num != 0)
+	{
+		task_ptr->next_tcb = (task_ptr-1)->next_tcb;
 		(task_ptr-1)->next_tcb = task_ptr;
+	}
+	else
+	{
+		tcb *first_occ=&tcbs[0];
+		tcb *last_occ=&tcbs[0];
 
-	task_ptr->next_tcb = &tcbs[0];
+		while(counter < MAX_TASKS)
+		{
+			if(active_tasks[counter] != 0)
+				if(first_occ == &tcbs[0])
+					first_occ += counter;
+				last_occ=&tcbs[0]+counter;
+			counter++;
+		}
+
+		task_ptr->next_tcb = first_occ;
+		last_occ->next_tcb = task_ptr;
+	}
+	
 	task_ptr->pid = task_num;
+
 #ifdef weighted_round_robin
 	task_ptr->weight = weight;
 	task_ptr->c_weight = weight;
 #endif
+
 	wee_os_stack_init(task_num);
 	STACK[task_num][PC] = (int32_t)task;
-
-	task_ptr++;
+	active_tasks[task_num] = 1;
 
 	__enable_irq();
 	return 1;
 }
+
 
 static void wee_os_schd_launch()
 {

--- a/src/Kernel/Src/weeOs.c
+++ b/src/Kernel/Src/weeOs.c
@@ -43,10 +43,12 @@ uint8_t wee_os_addthread(void(*task)(void)
 
 		while(counter < MAX_TASKS)
 		{
-			if(active_tasks[counter] != 0)
+			if(active_tasks[counter] == 1)
+			{
 				if(first_occ == &tcbs[0])
 					first_occ += counter;
-				last_occ=&tcbs[0]+counter;
+				last_occ = &tcbs[0]+counter;
+			}
 			counter++;
 		}
 

--- a/src/Kernel/Src/weeOs.c
+++ b/src/Kernel/Src/weeOs.c
@@ -50,7 +50,6 @@ uint8_t wee_os_addthread(void(*task)(void)
 				if(first_occ == &tcbs[0])
 					first_occ += counter;
 				last_occ = &tcbs[0]+counter;
-			}
 			counter++;
 		}
 

--- a/src/Kernel/Src/weeOs.c
+++ b/src/Kernel/Src/weeOs.c
@@ -26,7 +26,6 @@ uint8_t wee_os_addthread(void(*task)(void)
 	while(active_tasks[counter] != 0){
 		counter++;
 		if (counter>MAX_TASKS){
-			__enable_irq();
 			return 0;
 		}
 	}


### PR DESCRIPTION
Adding kill thread system call. When there is just one thread running, it returns 0.
Adding logic for adding task at the first possible empty spot in tcbs array.
Potentially fixed yield issue by resetting systick value to 0 every-time we yield.